### PR TITLE
Revert "Bump to Coq 8.15.1"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: ci
 
 env:
-  COQ_VERSION: 8.15.1
+  COQ_VERSION: 8.15
   IRIS_VERSION: 3.6.0
 
 on:


### PR DESCRIPTION
Reverts Blaisorblade/docker-dot-iris#7