### PR TITLE
Use a build matrix for the Iris versions I want

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # Don't abort other jobs when one fails!
       matrix:
         iris: [3.6.0, 4.0.0]
         coq: [8.15]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,5 @@
 name: ci
 
-env:
-  COQ_VERSION: 8.15
-  IRIS_VERSION: 3.6.0
-
 on:
   push:
     branches:
@@ -15,6 +11,16 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        iris: [3.6.0, 4.0.0]
+        coq: [8.15]
+        include:
+          - iris: 4.0.0
+            coq: 8.16
+    env:
+      COQ_VERSION: ${{ matrix.coq }}
+      IRIS_VERSION: ${{ matrix.iris }}
     steps:
       -
         name: Set up QEMU

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,20 +24,20 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,9 +18,6 @@ jobs:
         include:
           - iris: 4.0.0
             coq: 8.16
-    env:
-      COQ_VERSION: ${{ matrix.coq }}
-      IRIS_VERSION: ${{ matrix.iris }}
     steps:
       -
         name: Set up QEMU
@@ -41,6 +38,6 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            COQ_VERSION=${{ env.COQ_VERSION }}
-            IRIS_VERSION=${{ env.IRIS_VERSION }}
-          tags: blaisorblade/docker-dot-iris:coq-${{ env.COQ_VERSION }}-iris-${{ env.IRIS_VERSION }}
+            COQ_VERSION=${{ matrix.coq }}
+            IRIS_VERSION=${{ matrix.iris }}
+          tags: blaisorblade/docker-dot-iris:coq-${{ matrix.coq }}-iris-${{ matrix.iris }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
   && eval `opam env` \
   && opam update -y \
   && opam pin add -y -n -k version coq-iris ${IRIS_VERSION} \
-  && opam pin add -y -n -k version coq-autosubst 1.7 \
+  && opam pin add -y -n -k version coq-autosubst dev \
   && opam install -y -v -j ${NJOBS} coq-iris coq-autosubst \
   && /tmp/opam-clean.sh \
   && opam config list && opam list


### PR DESCRIPTION
Rationale: 
- images must be rebuilt periodically to give fast builds.
- I'm developing dot-iris on multiple branches.